### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,25 @@ on:
       - main
 
 jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    outputs:
+      short_sha: ${{ steps.set_outputs.outputs.short_sha }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set outputs
+        id: set_outputs
+        run: |
+          echo "::set-output name=short_sha::$(git rev-parse --short "${GITHUB_SHA}")"
+
   build:
     name: Build
+    needs:
+      - prepare
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -35,31 +52,24 @@ jobs:
   deploy:
     name: Deploy
     needs:
+      - prepare
       - build
     if: |
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          ref: gh-pages
-          path: gh-pages
       - name: Download GitHub Pages from artifact
         uses: actions/download-artifact@v2
         with:
           name: gh-pages
           path: _site
-      - name: Sync changes to GitHub Pages branch
-        run: |
-          rsync --archive --checksum --delete-after --exclude=.git --verbose _site/ gh-pages/
-      - name: Push changes to GitHub Pages branch
-        working-directory: gh-pages
-        run: |
-          touch .nojekyll
-          git config --local user.name 'github-actions[bot]'
-          git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add --all .
-          git commit --message="Deploy GitHub Pages from commit $(git rev-parse --short "${GITHUB_SHA}")" || true
-          git push origin gh-pages
+      - name: Deploy to GitHub Pages branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _site
+          publish_branch: gh-pages
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          full_commit_message: Deploy Jekyll site from ${{ needs.prepare.outputs.short_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,4 @@ jobs:
           publish_branch: gh-pages
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
-          full_commit_message: Deploy Jekyll site from ${{ needs.prepare.outputs.short_sha }}
+          full_commit_message: Deploy GitHub Pages from commit ${{ needs.prepare.outputs.short_sha }}


### PR DESCRIPTION
This pull request makes GitHub Actions use [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) to deploy pages.
